### PR TITLE
feat: restrict bot access to allowed users only

### DIFF
--- a/src/commands/cliPath.ts
+++ b/src/commands/cliPath.ts
@@ -1,5 +1,5 @@
 import type TelegramBot from "node-telegram-bot-api";
-import { log } from "../utils";
+import { log, isUserAuthorized } from "../utils";
 import { config } from "../config";
 
 export const cliPathCommand = {
@@ -7,6 +7,11 @@ export const cliPathCommand = {
   description: "Get the path to Claude Code CLI",
   handler: (bot: TelegramBot) => {
     bot.onText(/\/cli_path/, (msg) => {
+      // Check if user is authorized - silently ignore unauthorized users
+      if (!isUserAuthorized(msg.from?.id)) {
+        return;
+      }
+
       const chatId = msg.chat.id;
       log("info", "Command received", {
         command: "/cli_path",

--- a/src/commands/myq.ts
+++ b/src/commands/myq.ts
@@ -1,5 +1,5 @@
 import type TelegramBot from "node-telegram-bot-api";
-import { log } from "../utils";
+import { log, isUserAuthorized } from "../utils";
 import { queryAgentStream, saveSessionId } from "../services";
 
 export const myqCommand = {
@@ -7,6 +7,11 @@ export const myqCommand = {
   description: "Control myQ garage door",
   handler: (bot: TelegramBot) => {
     bot.onText(/\/myq(?:\s+(.+))?/, async (msg, match) => {
+      // Check if user is authorized - silently ignore unauthorized users
+      if (!isUserAuthorized(msg.from?.id)) {
+        return;
+      }
+
       const chatId = msg.chat.id;
       const messageId = msg.message_id;
       const args = match?.[1]?.trim();

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,11 +1,16 @@
 import type TelegramBot from "node-telegram-bot-api";
-import { log } from "../utils";
+import { log, isUserAuthorized } from "../utils";
 
 export const startCommand = {
   command: "start",
   description: "Start interacting with the bot",
   handler: (bot: TelegramBot) => {
     bot.onText(/\/start/, (msg) => {
+      // Check if user is authorized - silently ignore unauthorized users
+      if (!isUserAuthorized(msg.from?.id)) {
+        return;
+      }
+
       const chatId = msg.chat.id;
       log("info", "Command received", {
         command: "/start",

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ class Config {
   readonly anthropicApiKey: string;
   readonly claudeCodePath: string;
   readonly assemblyAiApiKey?: string;
+  readonly allowedUsers: number[];
 
   constructor() {
     const telegramBotToken = process.env.TELEGRAM_BOT_TOKEN;
@@ -27,6 +28,16 @@ class Config {
 
     // AssemblyAI API key (optional, for voice message transcription)
     this.assemblyAiApiKey = process.env.ASSEMBLYAI_API_KEY;
+
+    // Allowed Telegram user IDs (comma-separated list)
+    // If empty or not set, all users are allowed (for development convenience)
+    const allowedUsersEnv = process.env.ALLOWED_USERS;
+    this.allowedUsers = allowedUsersEnv
+      ? allowedUsersEnv
+          .split(",")
+          .map((id) => parseInt(id.trim(), 10))
+          .filter((id) => !isNaN(id))
+      : [];
   }
 }
 

--- a/src/handlers/message.ts
+++ b/src/handlers/message.ts
@@ -1,5 +1,5 @@
 import TelegramBot from "node-telegram-bot-api";
-import { log, splitMessage, markdownToTelegram } from "../utils";
+import { log, splitMessage, markdownToTelegram, isUserAuthorized } from "../utils";
 import {
   queryAgentStream,
   getSessionId,
@@ -14,6 +14,11 @@ export function registerMessageHandler(bot: TelegramBot) {
   bot.on("message", async (msg) => {
     const chatId = msg.chat.id;
     const messageId = msg.message_id;
+
+    // Check if user is authorized - silently ignore unauthorized users
+    if (!isUserAuthorized(msg.from?.id)) {
+      return;
+    }
 
     let text: string | undefined;
     let isVoiceMessage = false;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,28 @@
+import { config } from "../config";
+import { log } from "./logger";
+
+/**
+ * Checks if a user is authorized to interact with the bot.
+ * If ALLOWED_USERS is empty or not set, all users are allowed.
+ * @param userId - The Telegram user ID to check
+ * @returns true if the user is authorized, false otherwise
+ */
+export function isUserAuthorized(userId: number | undefined): boolean {
+  // If no user ID provided, deny access
+  if (userId === undefined) {
+    return false;
+  }
+
+  // If no allowed users are configured, allow all users (development mode)
+  if (config.allowedUsers.length === 0) {
+    return true;
+  }
+
+  const isAllowed = config.allowedUsers.includes(userId);
+
+  if (!isAllowed) {
+    log("warn", "Unauthorized user attempted to access the bot", { userId });
+  }
+
+  return isAllowed;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { log } from "./logger";
 export { splitMessage } from "./message";
 export { markdownToTelegram } from "./telegram";
+export { isUserAuthorized } from "./auth";


### PR DESCRIPTION
## Summary
- Add `ALLOWED_USERS` environment variable support for restricting bot access to specific Telegram user IDs
- Create `isUserAuthorized` utility function to check user authorization
- Add authorization checks to message handler and all command handlers (`/start`, `/cli_path`, `/myq`)
- Unauthorized users are silently ignored (no error messages)
- If `ALLOWED_USERS` is not set or empty, all users are allowed (for development convenience)

## Test plan
- [ ] Set `ALLOWED_USERS` env var to a comma-separated list of Telegram user IDs (e.g., `ALLOWED_USERS=123456789,987654321`)
- [ ] Verify that authorized users can send messages and use commands
- [ ] Verify that unauthorized users receive no response (silent ignore)
- [ ] Verify that when `ALLOWED_USERS` is not set, all users can interact with the bot

Closes #3

---
Generated with [Claude Code](https://claude.com/claude-code)